### PR TITLE
fix: fixed head cell key to work with duplicating column names

### DIFF
--- a/src/lib/DataTable.tsx
+++ b/src/lib/DataTable.tsx
@@ -251,7 +251,7 @@ class TableHead<T> extends React.Component<TableHeadProps<T>> {
             <th
                 ref={column.dataColumn ? this._getColumnRef(columnIndex!) : null}
                 className={b('th', {sortable, align}, className)}
-                key={column.name}
+                key={`${column.name}-${index}`}
                 title={headerTitle}
                 data-index={index}
                 colSpan={colSpan}


### PR DESCRIPTION
Using key as `column.name` is not correct, because in case when user provides duplicating column names, react fails to refresh elements

Originaly it is bad idea to pass identical column names, but we use data-table with postgresql, where identical column names is real case. For example, `SELECT 1, 2, 3` – column names are three times `?column?`. In such case rendering of data-table is failing.

